### PR TITLE
Add file browsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v0.3.2-beta
+
 - Fixed a mistake in the README instructions for where to move the app once compiled
   - In the distant past, we were creating a subfolder in the Applications folder (/Applications/Blue\ and\ Pink\ Synth\ Editor/)
   - However, when we switched to using no subfolder I failed to update the README

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Changed presets spinner so it always has the same number of items
   - The first one always shows the name of the current preset
 - Now the preset + and - buttons browse through the preset slots but do not pass through the init preset.
+- File load and save dialogs now sort the files alphabetically
 
 
 ## v0.3.1-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
 - Implemented activation code functionality (disabled by default)
   - By default, the app does not require an activation code. However, if the function in activation_code_enabled.py is changed to return True then the app runs in demo mode unless a valid activation code has been loaded.
 - Swapped the incoming and outgoing port numbers for communicating with nymphes-osc. I had accidentally mixed them up a while ago, and I've only now realized that the port sending messages to nymphes-osc match nymphes-osc's default listening port. It's not a huge issue, but was a little confusing to me.
-
+- Changed presets spinner so it always has the same number of items
+  - The first one always shows the name of the current preset
+- Now the preset + and - buttons browse through the preset slots but do not pass through the init preset.
 
 
 ## v0.3.1-beta

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,9 @@
 - Swapped the incoming and outgoing port numbers for communicating with nymphes-osc. I had accidentally mixed them up a while ago, and I've only now realized that the port sending messages to nymphes-osc match nymphes-osc's default listening port. It's not a huge issue, but was a little confusing to me.
 - Changed presets spinner so it always has the same number of items
   - The first one always shows the name of the current preset
-- Now the preset + and - buttons browse through the preset slots but do not pass through the init preset.
+- Now the preset + and - buttons cycle through the preset slots but do not pass through the init preset.
 - File load and save dialogs now sort the files alphabetically
+- New Feature: Preset + and - buttons now cycle through preset files if one is currently loaded
 
 
 ## v0.3.1-beta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BlueAndPinkSynthEditor"
-version = "0.2.5-beta"
+version = "0.3.2-beta"
 description = "A full-featured editor for the Dreadbox Nymphes MIDI synthesizer"
 readme = "README.md"
 authors = [{name = "Scott Lumsden", email = "jtpack@gmail.com"}]

--- a/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
+++ b/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
@@ -520,8 +520,7 @@ class BlueAndPinkSynthEditorApp(App):
         #
         # Presets Spinner Stuff
         #
-
-        values = ['init']
+        values = ['init', 'init']
         values.extend(
             [f'{kind} {bank}{num}' for kind in ['USER', 'FACTORY'] for bank in ['A', 'B', 'C', 'D', 'E', 'F', 'G']
              for num in [1, 2, 3, 4, 5, 6, 7]])
@@ -918,130 +917,71 @@ class BlueAndPinkSynthEditorApp(App):
 
     def presets_spinner_text_changed(self, spinner_index, spinner_text):
         if self._curr_presets_spinner_index != spinner_index:
+
+            if spinner_index == 0:
+                # Don't do anything if the user taps the first
+                # option, as it is only supposed to be an indicator
+                # of which preset is loaded.
+                return
+
             # Store the new index
             self._curr_presets_spinner_index = spinner_index
 
-            if len(self.presets_spinner_values) == 99:
-                #
-                # No file has been loaded or saved, so the first
-                # item in the list is the init file.
-                #
-                if spinner_index == 0:
-                    # Load the init preset file
-                    self.send_nymphes_osc('/load_init_file')
-
-                else:
-                    # This is a preset slot
-                    self.load_preset_by_index(spinner_index - 1)
+            if spinner_index == 1:
+                # Load the init preset file
+                self.send_nymphes_osc('/load_init_file')
 
             else:
-                #
-                # A file has been loaded or saved, so the first item
-                # in the list is the filename, and the second item is
-                # the init file.
-                #
-                if spinner_index == 0:
-                    # Reload the most recent preset file.
-                    self.send_nymphes_osc('/load_file', str(self._curr_preset_file_path))
-
-                elif spinner_index == 1:
-                    # Load the init preset file
-                    self.send_nymphes_osc('/load_init_file')
-
-                else:
-                    # This is a preset slot
-                    self.load_preset_by_index(spinner_index - 2)
+                # This is a preset slot
+                self.load_preset_by_index(spinner_index - 2)
 
     def load_next_preset(self):
 
-        if len(self.presets_spinner_values) == 99:
-            #
-            # No file has been loaded or saved, so the first
-            # item in the list is the init file.
-            #
+        if self.curr_preset_type == 'init':
+            # The init preset is loaded.
+            # Do nothing.
+            return
 
-            if self._curr_presets_spinner_index + 1 > 98:
-                # Wrap around to the beginning of the list
-                self._curr_presets_spinner_index = 0
+        elif self.curr_preset_type == 'preset_slot':
 
-                # Load the init preset file
-                self.send_nymphes_osc('/load_init_file')
-
-            else:
-                # Load the next preset slot
-                self._curr_presets_spinner_index += 1
-                self.load_preset_by_index(self._curr_presets_spinner_index - 1)
-
-        else:
-            #
-            # A file has been loaded or saved, so the first item
-            # in the list is the filename, and the second item is
-            # the init file.
-            #
-
-            if self._curr_presets_spinner_index + 1 >= len(self.presets_spinner_values):
-                # Wrap around to the beginning of the list
-                self._curr_presets_spinner_index = 0
-
-                # Reload the most recent preset file
-                self.send_nymphes_osc('/load_file', str(self._curr_preset_file_path))
-
-            elif self._curr_presets_spinner_index + 1 == 1:
-                # Load the init preset file
-                self._curr_presets_spinner_index = 1
-                self.send_nymphes_osc('/load_init_file')
-
-            else:
+            if self._curr_presets_spinner_index < 99:
                 # Load the next preset slot
                 self._curr_presets_spinner_index += 1
                 self.load_preset_by_index(self._curr_presets_spinner_index - 2)
+
+            else:
+                # Wrap around to the beginning of the list
+                self._curr_presets_spinner_index = 2
+
+                # Load the first preset slot
+                self.load_preset_by_index(0)
+
+        elif self.curr_preset_type == 'file':
+            print('load next file...')
+
 
     def load_prev_preset(self):
-        if len(self.presets_spinner_values) == 99:
-            #
-            # No file has been loaded or saved, so the first
-            # item in the list is the init file.
-            #
-            if self._curr_presets_spinner_index - 1 == 0:
-                # Load the init preset file
-                self._curr_presets_spinner_index = 0
-                self.send_nymphes_osc('/load_init_file')
+        if self.curr_preset_type == 'init':
+            # The init preset is loaded.
+            # Do nothing.
+            return
 
-            elif self._curr_presets_spinner_index - 1 < 0:
-                # Wrap around to the end of the list
-                self._curr_presets_spinner_index = 98
-                self.load_preset_by_index(97)
+        elif self.curr_preset_type == 'preset_slot':
+
+            if self._curr_presets_spinner_index > 2:
+                # Load the previous preset slot
+                self._curr_presets_spinner_index -= 1
+                self.load_preset_by_index(self._curr_presets_spinner_index - 2)
 
             else:
-                # Load the previous preset
-                self._curr_presets_spinner_index -= 1
-                self.load_preset_by_index(self._curr_presets_spinner_index - 1)
-
-        else:
-            #
-            # A file has been loaded or saved, so the first item
-            # in the list is the filename, and the second item is
-            # the init file.
-            #
-            if self._curr_presets_spinner_index - 1 == 1:
-                # Load the init preset file
-                self._curr_presets_spinner_index = 1
-                self.send_nymphes_osc('/load_init_file')
-
-            elif self._curr_presets_spinner_index - 1 == 0:
-                # Reload the most recent preset file
-                self._curr_presets_spinner_index = 0
-                self.send_nymphes_osc('/load_file', str(self._curr_preset_file_path))
-
-            elif self._curr_presets_spinner_index - 1 < 0:
                 # Wrap around to the end of the list
                 self._curr_presets_spinner_index = 99
+
+                # Load the last preset slot
                 self.load_preset_by_index(self._curr_presets_spinner_index - 2)
 
-            else:
-                # Load the previous preset
-                self._curr_presets_spinner_index = self._curr_presets_spinner_index - 1
-                self.load_preset_by_index(self._curr_presets_spinner_index - 2)
+        elif self.curr_preset_type == 'file':
+            print('load next file...')
 
     def increment_prop_value_for_param_name(self, param_name, amount):
         # Convert the parameter name to the name
@@ -1751,6 +1691,8 @@ class BlueAndPinkSynthEditorApp(App):
             #
             # The Nymphes synthesizer has just loaded a preset
             #
+
+            # Parse it
             preset_slot_type = str(args[0])
             preset_slot_bank_and_number = str(args[1]), int(args[2])
 
@@ -1767,7 +1709,7 @@ class BlueAndPinkSynthEditorApp(App):
             self._curr_preset_slot_type = preset_slot_type
             self._curr_preset_slot_bank_and_number = preset_slot_bank_and_number
 
-            # Get the index of the loaded preset
+            # Get the index of the loaded preset slot
             preset_slot_index = BlueAndPinkSynthEditorApp.index_from_preset_info(
                 bank_name=self._curr_preset_slot_bank_and_number[0],
                 preset_num=self._curr_preset_slot_bank_and_number[1],
@@ -1775,12 +1717,12 @@ class BlueAndPinkSynthEditorApp(App):
             )
 
             # Calculate the index within the presets spinner options
-            preset_slot_start_index = 1 if len(self.presets_spinner_values) == 99 else 2
-            self._curr_presets_spinner_index = preset_slot_start_index + preset_slot_index
+            self._curr_presets_spinner_index = 2 + preset_slot_index
 
             # Update the preset spinner's text
-            if self.presets_spinner_text != self.presets_spinner_values[self._curr_presets_spinner_index]:
-                self.presets_spinner_text = self.presets_spinner_values[self._curr_presets_spinner_index]
+            preset_name = self.presets_spinner_values[self._curr_presets_spinner_index]
+            if self.presets_spinner_text != preset_name:
+                self._set_presets_spinner_first_option_on_main_thread(preset_name)
 
             # Status bar message
             self._set_prop_value_on_main_thread('status_bar_text',
@@ -1826,9 +1768,7 @@ class BlueAndPinkSynthEditorApp(App):
             self._set_prop_value_on_main_thread('unsaved_preset_changes', False)
 
             # Update the presets spinner.
-            # This also sets the spinner's current text
-            # and updates self._curr_presets_spinner_index.
-            self._set_presets_spinner_file_option_on_main_thread(self._curr_preset_file_path.stem)
+            self._set_presets_spinner_first_option_on_main_thread(self._curr_preset_file_path.stem)
 
             # Status bar message
             msg = f'LOADED {filepath.name}'
@@ -1859,8 +1799,8 @@ class BlueAndPinkSynthEditorApp(App):
 
             # Update the presets spinner
             # Select the init option
-            self._set_prop_value_on_main_thread('presets_spinner_text', 'init')
-            self._curr_presets_spinner_index = 0 if len(self.presets_spinner_values) == 99 else 1
+            self._set_presets_spinner_first_option_on_main_thread('init')
+            self._curr_presets_spinner_index = 1
 
             # Status bar message
             msg = f'LOADED INIT PRESET (init.txt)'
@@ -1882,9 +1822,7 @@ class BlueAndPinkSynthEditorApp(App):
                 self._curr_preset_file_path = filepath
 
                 # Update the presets spinner.
-                # This also sets the spinner's current text
-                # and updates self._curr_presets_spinner_index.
-                self._set_presets_spinner_file_option_on_main_thread(self._curr_preset_file_path.name)
+                self._set_presets_spinner_first_option_on_main_thread(self._curr_preset_file_path.name)
 
                 # Status bar message
                 msg = f'SAVED {filepath.name} PRESET FILE'
@@ -1896,14 +1834,11 @@ class BlueAndPinkSynthEditorApp(App):
                 # than a regular preset file
 
                 # Update the current preset type
+                self._set_presets_spinner_first_option_on_main_thread('init')
                 self._set_prop_value_on_main_thread('curr_preset_type', 'init')
 
                 # Store the path to the file
                 self._curr_preset_file_path = filepath
-
-                # Update the presets spinner
-                # Sending it None removes the file option and selects the first entry (init)
-                self._set_presets_spinner_file_option_on_main_thread(None)
 
                 # Status bar message
                 msg = f'UPDATED INIT PRESET (init.txt)'
@@ -2426,44 +2361,17 @@ class BlueAndPinkSynthEditorApp(App):
                 # Resize the window, using the scaling
                 Window.size = (width, new_height)
 
-    def _set_presets_spinner_file_option_on_main_thread(self, option_text):
+    def _set_presets_spinner_first_option_on_main_thread(self, option_text):
         """
         Replace the first item in the self.presets_spinner_values ListProperty
         with new_text and update the spinner text, but do it on the Main thread.
-        If a file has just been loaded or saved for the first time, then insert
-        the option at the beginning of the list and then select it.
-        If option_text is None, then remove the file option from the list.
-        This is needed if the change occurs in response to an OSC message on a
-        background thread.
+        Also set the preset_spinner_text property
         :param option_text: str
         :return:
         """
         def work_func(_, new_text):
-            if new_text is None:
-                # We need to remove the file option from the list
-                if len(self.presets_spinner_values) != 99:
-                    self.presets_spinner_values.pop(0)
-
-                # Select the first entry
-                self.presets_spinner_text = self.presets_spinner_values[0]
-                self._curr_presets_spinner_index = 0
-            else:
-                # new_text is not None, so we are setting the file
-                # option or adding it if it doesn't exist
-                if len(self.presets_spinner_values) == 99:
-                    # No file has previously been loaded or saved,
-                    # so we need to insert the new filename at the
-                    # beginning of the list
-                    self.presets_spinner_values.insert(0, new_text)
-
-                else:
-                    # There is already a spot at the beginning of
-                    # the list for the filename
-                    self.presets_spinner_values[0] = new_text
-
-                # Update the preset spinner text
-                self.presets_spinner_text = self.presets_spinner_values[0]
-                self._curr_presets_spinner_index = 0
+            self.presets_spinner_values[0] = new_text
+            self.presets_spinner_text = new_text
 
         Clock.schedule_once(lambda dt: work_func(dt, option_text), 0)
 

--- a/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
+++ b/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
@@ -83,7 +83,7 @@ from src.blue_and_pink_synth_editor.activation_code_enabled import activation_co
 
 kivy.require('2.1.0')
 
-app_version_string = 'v0.3.1-beta_dev'
+app_version_string = 'v0.3.2-beta_dev'
 
 
 class BlueAndPinkSynthEditorApp(App):

--- a/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
+++ b/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
@@ -2846,3 +2846,7 @@ class BlueAndPinkSynthEditorApp(App):
         returns: tuple of prev file and next file
         """
         pass
+
+    @staticmethod
+    def file_list_sort_func(file_paths, filesystem):
+        return sorted(file_paths, key=lambda file_path: file_path.lower())

--- a/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
+++ b/src/blue_and_pink_synth_editor/BlueAndPinkSynthEditorApp.py
@@ -2836,3 +2836,13 @@ class BlueAndPinkSynthEditorApp(App):
         Logger.info('Demo mode timer ended')
 
         self._show_demo_mode_popup(can_be_dismissed=False)
+
+    def _get_next_and_prev_files_for_file_path(self, file_path):
+        """
+        Gets a list of files in the parent folder of file_path, and
+        returns the paths of the next file and the previous file in
+        the folder. Wraps around if file_path is the last or first
+        file in the folder.
+        returns: tuple of prev file and next file
+        """
+        pass

--- a/src/blue_and_pink_synth_editor/ui_controls/bottom_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/bottom_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'bottom_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class BottomBar(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/chords_screen.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/chords_screen.py
@@ -6,8 +6,11 @@ from kivy.lang.builder import Builder
 from .misc_widgets import HoverButton
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'chords_screen.kv'))
- 
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
+
 
 class ChordsMainControlsBox(BoxLayout):
     screen_name = StringProperty('')

--- a/src/blue_and_pink_synth_editor/ui_controls/demo_mode_popup.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/demo_mode_popup.py
@@ -7,7 +7,10 @@ from kivy.properties import BooleanProperty
 from kivy.core.window import Window
 import webbrowser
 
-Builder.load_file(str(Path(__file__).parent / 'demo_mode_popup.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class DemoModePopup(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/error_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/error_dialog.py
@@ -5,7 +5,10 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'error_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ErrorDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/left_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/left_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'left_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class LeftBar(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
@@ -5,6 +5,9 @@
     FileChooserListView:
         id: filechooser
         path: str(app._presets_directory_path)
+        dirselect: False
+        filters: ['*.txt', '*.TXT']
+        sort_func: app.file_list_sort_func
     BoxLayout:
         size_hint_y: 1/8
         Button:

--- a/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
@@ -4,7 +4,7 @@
     orientation: 'vertical'
     FileChooserListView:
         id: filechooser
-        path: str(app._presets_directory_path)
+        path: str(app._curr_preset_file_path.parent if app._curr_preset_file_path is not None else app._presets_directory_path)
         dirselect: False
         filters: ['*.txt', '*.TXT']
         sort_func: app.file_list_sort_func

--- a/src/blue_and_pink_synth_editor/ui_controls/load_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/load_dialog.py
@@ -5,7 +5,10 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'load_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class LoadDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_lfo_config_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_lfo_config_cell.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_lfo_config_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridLfoConfigCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_mod_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_mod_cell.py
@@ -8,7 +8,10 @@ from kivy.uix.widget import Widget
 from kivy.app import App
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_mod_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridModCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_non_mod_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_non_mod_cell.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_non_mod_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridNonModCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
@@ -37,3 +37,5 @@
         id: filechooser
         path: str(app._presets_directory_path)
         on_selection: text_input.text = self.selection and self.selection[0] or ''
+        filters: ['*.txt', '*.TXT']
+        sort_func: app.file_list_sort_func

--- a/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
@@ -35,7 +35,7 @@
 
     FileChooserListView:
         id: filechooser
-        path: str(app._presets_directory_path)
+        path: str(app._curr_preset_file_path.parent if app._curr_preset_file_path is not None else app._presets_directory_path)
         on_selection: text_input.text = self.selection and self.selection[0] or ''
         filters: ['*.txt', '*.TXT']
         sort_func: app.file_list_sort_func

--- a/src/blue_and_pink_synth_editor/ui_controls/save_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/save_dialog.py
@@ -7,7 +7,10 @@ from kivy.clock import Clock
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'save_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class SaveDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/settings_screen.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/settings_screen.py
@@ -6,7 +6,10 @@ from kivy.uix.checkbox import CheckBox
 from kivy.uix.label import Label
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'settings_screen.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 class MidiInputPortsGrid(GridLayout):
     midi_ports = ListProperty([])

--- a/src/blue_and_pink_synth_editor/ui_controls/synth_editor_value_controls.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/synth_editor_value_controls.py
@@ -4,7 +4,10 @@ from kivy.app import App
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'synth_editor_value_controls.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class SynthEditorValueControl(ValueControl):

--- a/src/blue_and_pink_synth_editor/ui_controls/top_bar.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/top_bar.kv
@@ -102,7 +102,7 @@
     text_size: self.size
     halign: 'center'
     valign: 'middle'
-    disabled: not app.nymphes_connected
+    disabled: not app.nymphes_connected or app.curr_preset_type == 'init'
 
 
 <TopBarSpinner@HoverSpinner>:

--- a/src/blue_and_pink_synth_editor/ui_controls/top_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/top_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'top_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class TopBar(BoxLayout):


### PR DESCRIPTION
- Now the preset + and - buttons cycle through the preset slots but do not pass through the init preset.
- File load and save dialogs now sort the files alphabetically
- New Feature: Preset + and - buttons now cycle through preset files if one is currently loaded
