### PR TITLE
Version 0.3.2-beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+## v0.3.2-beta
+
 - Fixed a mistake in the README instructions for where to move the app once compiled
   - In the distant past, we were creating a subfolder in the Applications folder (/Applications/Blue\ and\ Pink\ Synth\ Editor/)
   - However, when we switched to using no subfolder I failed to update the README
@@ -9,7 +11,11 @@
 - Implemented activation code functionality (disabled by default)
   - By default, the app does not require an activation code. However, if the function in activation_code_enabled.py is changed to return True then the app runs in demo mode unless a valid activation code has been loaded.
 - Swapped the incoming and outgoing port numbers for communicating with nymphes-osc. I had accidentally mixed them up a while ago, and I've only now realized that the port sending messages to nymphes-osc match nymphes-osc's default listening port. It's not a huge issue, but was a little confusing to me.
-
+- Changed presets spinner so it always has the same number of items
+  - The first one always shows the name of the current preset
+- Now the preset + and - buttons cycle through the preset slots but do not pass through the init preset.
+- File load and save dialogs now sort the files alphabetically
+- New Feature: Preset + and - buttons now cycle through preset files if one is currently loaded
 
 
 ## v0.3.1-beta

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "BlueAndPinkSynthEditor"
-version = "0.2.5-beta"
+version = "0.3.2-beta"
 description = "A full-featured editor for the Dreadbox Nymphes MIDI synthesizer"
 readme = "README.md"
 authors = [{name = "Scott Lumsden", email = "jtpack@gmail.com"}]

--- a/src/blue_and_pink_synth_editor/ui_controls/bottom_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/bottom_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'bottom_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class BottomBar(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/chords_screen.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/chords_screen.py
@@ -6,8 +6,11 @@ from kivy.lang.builder import Builder
 from .misc_widgets import HoverButton
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'chords_screen.kv'))
- 
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
+
 
 class ChordsMainControlsBox(BoxLayout):
     screen_name = StringProperty('')

--- a/src/blue_and_pink_synth_editor/ui_controls/demo_mode_popup.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/demo_mode_popup.py
@@ -7,7 +7,10 @@ from kivy.properties import BooleanProperty
 from kivy.core.window import Window
 import webbrowser
 
-Builder.load_file(str(Path(__file__).parent / 'demo_mode_popup.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class DemoModePopup(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/error_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/error_dialog.py
@@ -5,7 +5,10 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'error_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ErrorDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/left_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/left_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'left_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class LeftBar(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/load_dialog.kv
@@ -4,7 +4,10 @@
     orientation: 'vertical'
     FileChooserListView:
         id: filechooser
-        path: str(app._presets_directory_path)
+        path: str(app._curr_preset_file_path.parent if app._curr_preset_file_path is not None else app._presets_directory_path)
+        dirselect: False
+        filters: ['*.txt', '*.TXT']
+        sort_func: app.file_list_sort_func
     BoxLayout:
         size_hint_y: 1/8
         Button:

--- a/src/blue_and_pink_synth_editor/ui_controls/load_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/load_dialog.py
@@ -5,7 +5,10 @@ from kivy.uix.boxlayout import BoxLayout
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'load_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class LoadDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_lfo_config_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_lfo_config_cell.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_lfo_config_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridLfoConfigCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_mod_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_mod_cell.py
@@ -8,7 +8,10 @@ from kivy.uix.widget import Widget
 from kivy.app import App
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_mod_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridModCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/params_grid_non_mod_cell.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/params_grid_non_mod_cell.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'params_grid_non_mod_cell.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class ParamsGridNonModCell(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/save_dialog.kv
@@ -35,5 +35,7 @@
 
     FileChooserListView:
         id: filechooser
-        path: str(app._presets_directory_path)
+        path: str(app._curr_preset_file_path.parent if app._curr_preset_file_path is not None else app._presets_directory_path)
         on_selection: text_input.text = self.selection and self.selection[0] or ''
+        filters: ['*.txt', '*.TXT']
+        sort_func: app.file_list_sort_func

--- a/src/blue_and_pink_synth_editor/ui_controls/save_dialog.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/save_dialog.py
@@ -7,7 +7,10 @@ from kivy.clock import Clock
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'save_dialog.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class SaveDialog(BoxLayout):

--- a/src/blue_and_pink_synth_editor/ui_controls/settings_screen.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/settings_screen.py
@@ -6,7 +6,10 @@ from kivy.uix.checkbox import CheckBox
 from kivy.uix.label import Label
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'settings_screen.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 class MidiInputPortsGrid(GridLayout):
     midi_ports = ListProperty([])

--- a/src/blue_and_pink_synth_editor/ui_controls/synth_editor_value_controls.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/synth_editor_value_controls.py
@@ -4,7 +4,10 @@ from kivy.app import App
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'synth_editor_value_controls.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class SynthEditorValueControl(ValueControl):

--- a/src/blue_and_pink_synth_editor/ui_controls/top_bar.kv
+++ b/src/blue_and_pink_synth_editor/ui_controls/top_bar.kv
@@ -102,7 +102,7 @@
     text_size: self.size
     halign: 'center'
     valign: 'middle'
-    disabled: not app.nymphes_connected
+    disabled: not app.nymphes_connected or app.curr_preset_type == 'init'
 
 
 <TopBarSpinner@HoverSpinner>:

--- a/src/blue_and_pink_synth_editor/ui_controls/top_bar.py
+++ b/src/blue_and_pink_synth_editor/ui_controls/top_bar.py
@@ -3,7 +3,10 @@ from kivy.properties import NumericProperty, StringProperty
 from kivy.lang.builder import Builder
 from pathlib import Path
 
-Builder.load_file(str(Path(__file__).parent / 'top_bar.kv'))
+# Import the kv file with the same name as this file
+parent_directory = Path(__file__).resolve().parent
+this_file_name = Path(__file__).stem
+Builder.load_file(str(parent_directory / f'{this_file_name}.kv'))
 
 
 class TopBar(BoxLayout):


### PR DESCRIPTION
- Fixed a mistake in the README instructions for where to move the app once compiled
  - In the distant past, we were creating a subfolder in the Applications folder (/Applications/Blue\ and\ Pink\ Synth\ Editor/)
  - However, when we switched to using no subfolder I failed to update the README
- Now using antialiased versions of RoundedRectangle and Rectangle
- Reorganized UI elements into separate py and kv files
  - Now it is much easier to navigate the project
- In the SETTINGS screen, now the OPEN PRESETS FOLDER and OPEN DEBUG LOGS FOLDER buttons are underlined
  - This makes them look like hyperlinks, which is more in line with how they actually work
- Implemented activation code functionality (disabled by default)
  - By default, the app does not require an activation code. However, if the function in activation_code_enabled.py is changed to return True then the app runs in demo mode unless a valid activation code has been loaded.
- Swapped the incoming and outgoing port numbers for communicating with nymphes-osc. I had accidentally mixed them up a while ago, and I've only now realized that the port sending messages to nymphes-osc match nymphes-osc's default listening port. It's not a huge issue, but was a little confusing to me.
- Changed presets spinner so it always has the same number of items
  - The first one always shows the name of the current preset
- Now the preset + and - buttons cycle through the preset slots but do not pass through the init preset.
- File load and save dialogs now sort the files alphabetically
- New Feature: Preset + and - buttons now cycle through preset files if one is currently loaded

* Changed presets spinner so it always has the same number of items. The first one always shows the name of the current preset. About to work on preset file browsing

* Getting started with preset file browsing via preset + and - buttons.

* File load and save dialogs now sort the files alphabetically.

* Implemented technique for loading kv files that was first used in Blue-and-Pink-Synth-Editor-RPi repository.

* New Feature: Preset + and - buttons now cycle through preset files if one is currently loaded

* Incremented app version to v0.3.2-beta.